### PR TITLE
refactor-config add description to composer for validation. rename/re…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "sourceability/coding-standard",
   "type": "phpcodesniffer-standard",
+  "description": "Sourceability coding standards for reuse.",
   "autoload": {
     "psr-4": {
       "Sourceability\\CodingStandard\\": "src/"

--- a/src/PhpCsFixerConfig.php
+++ b/src/PhpCsFixerConfig.php
@@ -4,7 +4,7 @@ namespace Sourceability\CodingStandard;
 
 use PhpCsFixer\Config;
 
-class SourceabilityPhpCsFixerConfig extends Config
+class PhpCsFixerConfig extends Config
 {
     public static function create()
     {


### PR DESCRIPTION
Remove sourceability prefix from class name since it is in Sourceability namespace. Add description property to Composer JSON for `composer validate`