### PR TITLE
Update requirements to enable upgrade to Composer 2 and PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,9 @@
     }
   },
   "require": {
-    "php": "^7.1",
-    "squizlabs/php_codesniffer": "^3.3.0",
-    "slevomat/coding-standard": "^6.0",
+    "php": "^7.1 || ^8.0",
+    "squizlabs/php_codesniffer": "^3.3",
+    "slevomat/coding-standard": "^6.4",
     "friendsofphp/php-cs-fixer": "^2.16"
   },
   "extra": {
@@ -24,6 +24,6 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.4"
+    "phpunit/phpunit": "^7.4 || ^9.3"
   }
 }


### PR DESCRIPTION
The package `dealerdirect/phpcodesniffer-composer-installer` is required by newer versions of `slevomat/coding-standard`.