### PR TITLE
Add sniff for collection aliases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor
 composer.lock
+.phpunit.result.cache
+.idea/
+.php-cs-fixer.cache

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ MAKEFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 COMPOSE_EXEC ?= docker-compose exec
 
 # Prefix any command that should be run within the fpm docker container with $(EXEC_FPM)
-EXEC_PHP ?= $(COMPOSE_EXEC) php-fpm
+EXEC_PHP ?= $(COMPOSE_EXEC) php
 ifeq (, $(shell which docker-compose))
 	EXEC_PHP =
 endif
@@ -14,5 +14,16 @@ endif
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
+.PHONY: bash
 bash: ## Starts a bash session in the php container
 	$(COMPOSE_EXEC) php /bin/sh
+
+.PHONY: pre-commit
+pre-commit:
+	$(EXEC_PHP) vendor/bin/php-cs-fixer fix --allow-risky=yes src
+	$(EXEC_PHP) vendor/bin/phpstan analyse src
+	$(EXEC_PHP) vendor/bin/phpunit tests
+
+.PHONY: tests
+tests:
+	$(EXEC_PHP) vendor/bin/phpunit tests

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,13 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Sourceability\\CodingStandard\\Tests\\": "tests/"
+      "Sourceability\\CodingStandard\\Tests\\": "tests/",
+      "PHP_CodeSniffer\\": "vendor/squizlabs/php_codesniffer/src/"
     }
   },
   "require": {
     "php": "^7.1 || ^8.0",
-    "squizlabs/php_codesniffer": "^3.3",
+    "squizlabs/php_codesniffer": "^3.8",
     "slevomat/coding-standard": "^7.0",
     "friendsofphp/php-cs-fixer": "^3.0"
   },
@@ -24,6 +25,12 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.4 || ^9.3"
+    "phpunit/phpunit": "^7.4 || ^9.3",
+    "phpspec/prophecy-phpunit": "^2.1",
+    "phpstan/phpstan": "^1.10",
+    "phpstan/phpstan-deprecation-rules": "^1.1",
+    "grifart/phpstan-oneline": "^0.4.2",
+    "ekino/phpstan-banned-code": "^1.0",
+    "phpstan/phpstan-strict-rules": "^1.5"
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: "3.2"
 
 services:
   php:
+    container_name: php
     build: .
     volumes:
       - .:/app

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,74 @@
+#
+# Tip: use \PHPStan\dumpType($a); to debug types
+#
+parameters:
+    level: 8
+    paths:
+        - '%currentWorkingDirectory%/src'
+    parallel:
+        processTimeout: 1000.0 # If this is not enough, allocate more cores to docker
+
+    compact:
+        format: "src/{path}:{line} {error}"
+
+    strictRules:
+        disallowedLooseComparison: false
+        booleansInConditions: false
+        uselessCast: false
+        requireParentConstructorCall: true
+        disallowedConstructs: true
+        overwriteVariablesWithLoop: true
+        closureUsesThis: true
+        matchingInheritedMethodNames: true
+        numericOperandsInArithmeticOperators: false
+        strictCalls: true
+        switchConditionsMatchingType: true
+        noVariableVariables: false
+
+    # See https://github.com/phpstan/phpstan-src/blob/0.12.56/conf/config.neon#L21-L44
+    checkUninitializedProperties: true
+    checkMissingIterableValueType: false
+
+    # https://github.com/phpstan/phpstan-strict-rules/blob/0.12.2/rules.neon
+    checkAlwaysTrueCheckTypeFunctionCall: true
+    checkAlwaysTrueInstanceof: true
+    checkExplicitMixedMissingReturn: false
+    checkFunctionNameCase: true
+    reportMaybesInMethodSignatures: false
+    reportStaticMethodSignatures: true
+    checkGenericClassInNonGenericObjectType: false
+    reportWrongPhpDocTypeInVarTag: false
+
+    banned_code:
+        # enable detection of `use Tests\Foo\Bar` in a non-test file
+        use_from_tests: true
+
+        nodes:
+            -
+                type: Expr_FuncCall
+                functions:
+                    - Functional\filter # Please use F\select instead
+                    - Functional\each # Please use the native foreach
+                    - Functional\partition # Please use foreach instead
+
+conditionalTags:
+    PHPStan\Rules\DisallowedConstructs\DisallowedShortTernaryRule:
+        phpstan.rules.rule: false
+
+includes:
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - vendor/grifart/phpstan-oneline/config.neon
+    - vendor/ekino/phpstan-banned-code/extension.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+
+services:
+    - class: PHPStan\Rules\Cast\UselessCastRule
+      arguments:
+          treatPhpDocTypesAsCertain: %treatPhpDocTypesAsCertain%
+      tags:
+          - phpstan.rules.rule
+
+    errorFormatter.table:
+        arguments:
+            relativePathHelper: @simpleRelativePathHelper

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -398,15 +398,15 @@
         <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing.IncorrectLinesCountBeforeControlStructure" />
         <exclude name="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing.IncorrectLinesCountBeforeFirstControlStructure" />
         <properties>
-            <property name="tokensToCheck" type="array">
-                <element value="T_IF" />
-                <element value="T_DO" />
-                <element value="T_WHILE" />
-                <element value="T_FOR" />
-                <element value="T_FOREACH" />
-                <element value="T_SWITCH" />
-                <element value="T_TRY" />
-                <element value="T_DEFAULT" />
+            <property name="controlStructures" type="array">
+                <element value="if" />
+                <element value="do" />
+                <element value="while" />
+                <element value="for" />
+                <element value="foreach" />
+                <element value="switch" />
+                <element value="try" />
+                <element value="default" />
             </property>
         </properties>
     </rule>

--- a/src/PHPCS/Sniffs/ForbiddenConstantSniff.php
+++ b/src/PHPCS/Sniffs/ForbiddenConstantSniff.php
@@ -4,6 +4,7 @@ namespace Sourceability\CodingStandard\PHPCS\Sniffs;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+
 use const T_CLASS_C;
 use const T_FUNC_C;
 use const T_LINE;

--- a/src/PHPCS/Sniffs/NoCollectionAliasesSniff.php
+++ b/src/PHPCS/Sniffs/NoCollectionAliasesSniff.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Sourceability\CodingStandard\PHPCS\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use function sprintf;
+use const T_OBJECT_OPERATOR;
+use const T_STRING;
+
+class NoCollectionAliasesSniff implements Sniff
+{
+    private const FORBIDDEN_ALIASES = [
+        'average' => 'avg',
+        'some' => 'contains',
+        'unlessEmpty' => 'whenNotEmpty',
+        'unlessNotEmpty' => 'whenEmpty',
+    ];
+
+    public function register()
+    {
+        return [
+            T_OBJECT_OPERATOR,
+        ];
+    }
+
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+        $collectLocation = $phpcsFile->findPrevious(T_STRING, $stackPtr - 1, null, false, 'collect', true);
+        if ($collectLocation === false) {
+            return;
+        }
+
+        $methodName = $tokens[$stackPtr + 1]['content'];
+        if(array_key_exists($methodName, self::FORBIDDEN_ALIASES)) {
+            $phpcsFile->addError(
+                sprintf('Use of collection method alias "%s" is forbidden, use "%s" instead', $methodName, self::FORBIDDEN_ALIASES[$methodName]),
+                $stackPtr,
+                'ForbiddenAlias'
+            );
+        }
+    }
+}

--- a/src/PHPCS/Sniffs/NoCollectionAliasesSniff.php
+++ b/src/PHPCS/Sniffs/NoCollectionAliasesSniff.php
@@ -4,10 +4,9 @@ namespace Sourceability\CodingStandard\PHPCS\Sniffs;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
-use PhpCsFixer\Fixer\FixerInterface;
-use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\Tokens;
+
 use function sprintf;
+
 use const T_OBJECT_OPERATOR;
 use const T_STRING;
 

--- a/src/PhpCsFixerConfig.php
+++ b/src/PhpCsFixerConfig.php
@@ -3,13 +3,13 @@
 namespace Sourceability\CodingStandard;
 
 use PhpCsFixer\Config;
+use PhpCsFixer\ConfigInterface;
 
 class PhpCsFixerConfig extends Config
 {
-    public static function create()
+    public static function create(): ConfigInterface
     {
-        $config = new Config();
-        return $config->setRules([
+        return (new Config())->setRules([
             '@Symfony' => true,
             '@Symfony:risky' => true,
 
@@ -22,7 +22,9 @@ class PhpCsFixerConfig extends Config
             '@PHPUnit60Migration:risky' => true,
 
             'array_indentation' => true,
-            'array_syntax' => ['syntax' => 'short'],
+            'array_syntax' => [
+                'syntax' => 'short'
+            ],
 
             'compact_nullable_typehint' => true,
             'explicit_indirect_variable' => true,

--- a/src/PhpCsFixerConfig.php
+++ b/src/PhpCsFixerConfig.php
@@ -41,7 +41,6 @@ class PhpCsFixerConfig extends Config
             'no_superfluous_phpdoc_tags' => true,
             'no_unset_on_property' => true,
             'no_useless_return' => true,
-            'ordered_imports' => true,
             'phpdoc_order' => true,
             'return_assignment' => true,
 
@@ -49,23 +48,6 @@ class PhpCsFixerConfig extends Config
 
             'class_definition' => [
                 'single_line' => false,
-            ],
-
-            'ordered_class_elements' => [
-                'use_trait',
-                'constant_public',
-                'constant_protected',
-                'constant_private',
-                'property_public',
-                'property_protected',
-                'property_private',
-                'construct',
-                'destruct',
-                'magic',
-                'phpunit',
-                'method_public',
-                'method_protected',
-                'method_private',
             ],
 
             'ordered_imports' => [

--- a/tests/PHPCS/Sniffs/NoCollectionAliasesSniffTest.php
+++ b/tests/PHPCS/Sniffs/NoCollectionAliasesSniffTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Sourceability\CodingStandard\Tests\PHPCS\Sniffs;
+
+use PHP_CodeSniffer\Files\File;
+use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Sourceability\CodingStandard\PHPCS\Sniffs\NoCollectionAliasesSniff;
+
+class NoCollectionAliasesSniffTest extends TestCase
+{
+    use ProphecyTrait;
+
+    public function testSimpleAverage(): void
+    {
+        $stackPtr = 3; // The location of the first '->'
+        $file = $this->prophesize(File::class);
+        $file->getTokens()->willReturn([['content' => 'collect'], ['content' => '('],['content' => ')'],['content' => '->'],['content' => 'average'],['content' => '('], ['content' => ')']]);
+        $file->findPrevious(T_STRING, 2, null, false, 'collect', true)->willReturn(0);
+
+        $file->addError('Use of collection method alias "average" is forbidden, use "avg" instead', $stackPtr, 'ForbiddenAlias')->shouldBeCalled();
+
+        $sniff = new NoCollectionAliasesSniff();
+        $sniff->process($file->reveal(), $stackPtr);
+    }
+
+    public function testSimpleSome(): void
+    {
+        $stackPtr = 3; // The location of the first '->'
+        $file = $this->prophesize(File::class);
+        $file->getTokens()->willReturn([['content' => 'collect'], ['content' => '('],['content' => ')'],['content' => '->'],['content' => 'some'],['content' => '('], ['content' => ')']]);
+        $file->findPrevious(T_STRING, 2, null, false, 'collect', true)->willReturn(0);
+
+        $file->addError('Use of collection method alias "some" is forbidden, use "contains" instead', $stackPtr, 'ForbiddenAlias')->shouldBeCalled();
+
+        $sniff = new NoCollectionAliasesSniff();
+        $sniff->process($file->reveal(), $stackPtr);
+    }
+
+    public function testSimpleUnlessEmpty(): void
+    {
+        $stackPtr = 3; // The location of the first '->'
+        $file = $this->prophesize(File::class);
+        $file->getTokens()->willReturn([['content' => 'collect'], ['content' => '('],['content' => ')'],['content' => '->'],['content' => 'unlessEmpty'],['content' => '('], ['content' => ')']]);
+        $file->findPrevious(T_STRING, 2, null, false, 'collect', true)->willReturn(0);
+
+        $file->addError('Use of collection method alias "unlessEmpty" is forbidden, use "whenNotEmpty" instead', $stackPtr, 'ForbiddenAlias')->shouldBeCalled();
+
+        $sniff = new NoCollectionAliasesSniff();
+        $sniff->process($file->reveal(), $stackPtr);
+    }
+
+
+    public function testSimpleUnlessNotEmpty(): void
+    {
+        $stackPtr = 3; // The location of the first '->'
+        $file = $this->prophesize(File::class);
+        $file->getTokens()->willReturn([['content' => 'collect'], ['content' => '('],['content' => ')'],['content' => '->'],['content' => 'unlessNotEmpty'],['content' => '('], ['content' => ')']]);
+        $file->findPrevious(T_STRING, 2, null, false, 'collect', true)->willReturn(0);
+
+        $file->addError('Use of collection method alias "unlessNotEmpty" is forbidden, use "whenEmpty" instead', $stackPtr, 'ForbiddenAlias')->shouldBeCalled();
+
+        $sniff = new NoCollectionAliasesSniff();
+        $sniff->process($file->reveal(), $stackPtr);
+    }
+
+    public function testMoreAdvancedCase(): void
+    {
+        $badLine = 'collect($foo)->average(static fn (User $user) => $user->getId());';
+
+        $stackPtr = 4; // The location of the first '->'
+        $file = $this->prophesize(File::class);
+        $file->getTokens()->willReturn([['content' => 'collect'], ['content' => '('],['content' => '$foo'],['content' => ')'],['content' => '->'],['content' => 'average'],['content' => '('],['content' =>  'static'], ['content' => 'fn'],        ['content' => '('], ['content' => 'User'], ['content' => '$user'], ['content' => ')'], ['content' => '=>'], ['content' => '$user'], ['content' => '->'], ['content' => 'getId'], ['content' => '('], ['content' => ')'], ['content' => ')']]);
+        $file->findPrevious(T_STRING, 3, null, false, 'collect', true)->willReturn(0);
+
+        $file->addError('Use of collection method alias "average" is forbidden, use "avg" instead', $stackPtr, 'ForbiddenAlias')->shouldBeCalled();
+
+        $sniff = new NoCollectionAliasesSniff();
+        $sniff->process($file->reveal(), $stackPtr);
+    }
+}


### PR DESCRIPTION
This adds a new sniff to check for usage of a collection method that is an alias of another method.